### PR TITLE
chore(release): harden update-version.sh with set -euo pipefail

### DIFF
--- a/update-version.sh
+++ b/update-version.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 VERSION_NUMBER=$(grep '"version"' package.json | cut -d '"' -f 4)
 MAJOR_VERSION_NUMBER=$(echo "$VERSION_NUMBER" | cut -d '.' -f 1)
 VERSION=$(echo "v$VERSION_NUMBER")


### PR DESCRIPTION
## Summary
- Adds `#!/usr/bin/env bash` shebang and `set -euo pipefail` to `update-version.sh`.
- Without these, the release script silently continued past failures. Example: a failed `git push origin main` would not stop the subsequent `git tag` / `git push origin v1 --force`, leaving the local repo with tags that were never published, or a remote commit without its tag.

## Why now
Discovered during the v1.2.0 release prep for #20. No behavior change on the happy path — the existing `if git rev-parse ...` idiom is `set -e`-safe because `set -e` does not trigger inside conditionals.

## Test plan
- [x] `bash -n update-version.sh` (syntax OK)
- [ ] Manual: next release will exercise the hardened script

🤖 Generated with [Claude Code](https://claude.com/claude-code)