### PR TITLE
Version v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "github-action-build",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "github-action-build",
-      "version": "1.1.4",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-action-build",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "Github Action to automate the login process on Nullplatform",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
Release commit for v1.2.0. Bundles:

- `package.json` / `package-lock.json` bumped from `1.1.4` to `1.2.0`.
- `dist/index.js` regenerated via `npm run prepare`.

## Why this exists as a PR
The org-level `quality-gate` ruleset requires changes to `main` to go through a pull request. The release script `update-version.sh` historically pushed straight to `main`, which is no longer permitted. This PR carries the commit the script produced; tags will be created and pushed directly after merge (tags are not under the ruleset).

## Changes since v1.1.4
- #20 — Support `workflow_dispatch` for build description: fall back to fetching the commit message via the GitHub API when the event payload lacks `head_commit`.
- #21 — Harden `update-version.sh` with `set -euo pipefail`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)